### PR TITLE
Fix. Close autoCompleteLayer after empty input value

### DIFF
--- a/src/SweetSearch.js
+++ b/src/SweetSearch.js
@@ -105,7 +105,10 @@ class SweetSearch extends CommonComponent {
   handlerInputKeyInput(evt) {
     let sInputData = this.elInputField.value;
     if (sInputData.length > 0 ) _cu.setCSS(this.elClearQueryBtn, 'display', 'inline-block');
-    else _cu.closeLayer(this.elClearQueryBtn);
+    else {
+	    _cu.closeLayer(this.elClearQueryBtn);
+	    _cu.closeLayer(this.elAutoCompleteLayer);
+	}
 
     super.runCustomFn('PLUGIN', 'FN_AFTER_INPUT');
 


### PR DESCRIPTION
## Description

Now closing autoCompleteLayer after empty input value.
## Issue
#1
